### PR TITLE
Improve speed

### DIFF
--- a/lib/FIZZSCAN.ts
+++ b/lib/FIZZSCAN.ts
@@ -5,6 +5,8 @@
  * @copyright MIT
  */
 
+import KDBush from "kdbush";
+
 
 /**
  * FIZZSCAN class construcotr
@@ -29,7 +31,8 @@ class FIZZSCAN {
   _visited: Array<number>;
   _assigned: Array<number>;
   _datasetLength: number;
-  constructor(dataset: Array<Array<number>>, epsilon: number, minPts: number, forceIn: boolean, distanceFunction?: (p: any, q: any) => number) {
+  tree!: KDBush;
+  constructor(dataset: Array<Array<number>>, epsilon: number, minPts: number, forceIn: boolean, tree: KDBush, distanceFunction?: (p: any, q: any) => number) {
     /** @type {Array} */
     this.dataset = dataset;
     /** @type {number} */
@@ -58,7 +61,7 @@ class FIZZSCAN {
     this._assigned = [];
     /** @type {number} */
     this._datasetLength = dataset.length;
-
+    this.tree = tree
     this.run(dataset, epsilon, minPts, forceIn, distanceFunction);
   }
   /******************************************************************************/
@@ -128,8 +131,9 @@ class FIZZSCAN {
 
 
     let tempStorage: number[][] = [];
+    const alreadyClusterd = this.clusters.flat();
     for (let noisePointID of this.noise) {
-      let nearestNeighbor: number = this._nearestAssignedNeighbor(this.clusters.flat(), noisePointID);
+      const nearestNeighbor: number = this._nearestAssignedNeighbor(alreadyClusterd, noisePointID);
       tempStorage.push([noisePointID, Number(reverseClusterLookup[nearestNeighbor])]);
     }
 
@@ -255,22 +259,9 @@ class FIZZSCAN {
    * @access protected
    */
   _regionQuery(pointId: number): number[] {
-    let neighbors: number[] = [];
-    let nnDist: number = 0;
-    for (var id = 0; id < this._datasetLength; id++) {
-      var dist = this.distance(this.dataset[pointId], this.dataset[id]);
-      if (dist < this.epsilon) {
-        neighbors.push(id);
-      }
-      if (nnDist == 0) {
-        nnDist = dist;
-      }
-      else if (nnDist > dist) {
-        nnDist = dist;
-      }
-    }
-
-    return neighbors;
+    const targetPoint = this.dataset[pointId];
+    const nnTree = this.tree.within(targetPoint[0], targetPoint[1], this.epsilon);
+    return nnTree;
   }
   /******************************************************************************/
   // helpers
@@ -338,6 +329,14 @@ class FIZZSCAN {
  * @access protected
  */
   _nearestAssignedNeighbor(datasetIds: number[], pointId: number): number {
+    const treeNeighbors = this.tree.within(this.dataset[pointId][0], this.dataset[pointId][1], 2 * this.epsilon);
+    if (treeNeighbors.length > 0) {
+      for (let neighbor of treeNeighbors) {
+        if (datasetIds.includes(neighbor)) {
+          return neighbor;
+        }
+      }
+    }
     var nearest: number[] = [0, 0];
     for (var id of datasetIds) {
       if (nearest[1] == 0) {

--- a/lib/FIZZSCAN.ts
+++ b/lib/FIZZSCAN.ts
@@ -5,7 +5,8 @@
  * @copyright MIT
  */
 
-import KDBush from "kdbush";
+import KDBush from "./KDBush";
+
 
 
 /**

--- a/lib/FIZZSCAN.ts
+++ b/lib/FIZZSCAN.ts
@@ -132,9 +132,9 @@ class FIZZSCAN {
 
 
     let tempStorage: number[][] = [];
-    const alreadyClusterd = this.clusters.flat();
+    const alreadyClustered = this.clusters.flat();
     for (let noisePointID of this.noise) {
-      const nearestNeighbor: number = this._nearestAssignedNeighbor(alreadyClusterd, noisePointID);
+      const nearestNeighbor: number = this._nearestAssignedNeighbor(alreadyClustered, noisePointID);
       tempStorage.push([noisePointID, Number(reverseClusterLookup[nearestNeighbor])]);
     }
 

--- a/lib/FlatBush.ts
+++ b/lib/FlatBush.ts
@@ -1,0 +1,556 @@
+/*
+ISC License
+
+Copyright (c) 2022, Vladimir Agafonkin
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+*/
+
+import FlatQueue from "./FlatQueue";
+import { TypedArray } from "./KDBush";
+
+
+const ARRAY_TYPES = [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+const VERSION = 3; // serialized format version
+
+/** @typedef {Int8ArrayConstructor | Uint8ArrayConstructor | Uint8ClampedArrayConstructor | Int16ArrayConstructor | Uint16ArrayConstructor | Int32ArrayConstructor | Uint32ArrayConstructor | Float32ArrayConstructor | Float64ArrayConstructor} TypedArrayConstructor */
+/** @typedef {Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array} TypedArray */
+
+export default class Flatbush {
+    numItems: number;
+    nodeSize: number;
+    IndexArrayType
+    data: ArrayBufferLike;
+    _pos: number;
+    byteOffset: number;
+    _levelBounds: Array<number> = [];
+    ArrayType;
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+    _boxes;
+    _indices;
+    _queue;
+
+    /**
+     * Recreate a Flatbush index from raw `ArrayBuffer` or `SharedArrayBuffer` data.
+     * @param {ArrayBufferLike} data
+     * @param {number} [byteOffset=0] byte offset to the start of the Flatbush buffer in the referenced ArrayBuffer.
+     * @returns {Flatbush} index
+     */
+    static from(data: ArrayBufferLike, byteOffset = 0) {
+        if (byteOffset % 8 !== 0) {
+            throw new Error('byteOffset must be 8-byte aligned.');
+        }
+
+        if (!data || data.byteLength === undefined || 'buffer' in data) {
+            throw new Error('Data must be an instance of ArrayBuffer or SharedArrayBuffer.');
+        }
+
+        const [magic, versionAndType] = new Uint8Array(data, byteOffset + 0, 2);
+        if (magic !== 0xfb) {
+            throw new Error('Data does not appear to be in a Flatbush format.');
+        }
+        const version = versionAndType >> 4;
+        if (version !== VERSION) {
+            throw new Error(`Got v${version} data when expected v${VERSION}.`);
+        }
+        const ArrayType = ARRAY_TYPES[versionAndType & 0x0f];
+        if (!ArrayType) {
+            throw new Error('Unrecognized array type.');
+        }
+        const [nodeSize] = new Uint16Array(data, byteOffset + 2, 1);
+        const [numItems] = new Uint32Array(data, byteOffset + 4, 1);
+        //@ts-ignore
+        return new Flatbush(numItems, nodeSize, ArrayType, undefined, data, byteOffset);
+    }
+
+    /**
+     * Create a Flatbush index that will hold a given number of items.
+     * @param {number} numItems
+     * @param {number} [nodeSize=16] Size of the tree node (16 by default).
+     * @param {TypedArrayConstructor} [ArrayType=Float64Array] The array type used for coordinates storage (`Float64Array` by default).
+     * @param {ArrayBufferConstructor | SharedArrayBufferConstructor} [ArrayBufferType=ArrayBuffer] The array buffer type used to store data (`ArrayBuffer` by default).
+     * @param {ArrayBufferLike} [data] (Only used internally)
+     * @param {number} [byteOffset=0] (Only used internally)
+     */
+    constructor(numItems: number, nodeSize = 16, ArrayType = Float64Array, ArrayBufferType = ArrayBuffer, data: ArrayBufferLike | undefined, byteOffset = 0) {
+        if (numItems === undefined) throw new Error('Missing required argument: numItems.');
+        if (isNaN(numItems) || numItems <= 0) throw new Error(`Unexpected numItems value: ${numItems}.`);
+
+        this.numItems = +numItems;
+        this.nodeSize = Math.min(Math.max(+nodeSize, 2), 65535);
+        this.byteOffset = byteOffset;
+
+        // calculate the total number of nodes in the R-tree to allocate space for
+        // and the index of each tree level (used in search later)
+        let n = numItems;
+        let numNodes = n;
+        this._levelBounds = [n * 4];
+        do {
+            n = Math.ceil(n / this.nodeSize);
+            numNodes += n;
+            this._levelBounds.push(numNodes * 4);
+        } while (n !== 1);
+
+        this.ArrayType = ArrayType;
+        this.IndexArrayType = numNodes < 16384 ? Uint16Array : Uint32Array;
+
+        const arrayTypeIndex = ARRAY_TYPES.indexOf(ArrayType);
+        const nodesByteSize = numNodes * 4 * ArrayType.BYTES_PER_ELEMENT;
+
+        if (arrayTypeIndex < 0) {
+            throw new Error(`Unexpected typed array class: ${ArrayType}.`);
+        }
+
+        /** @type {new(b: ArrayBufferLike, o: number, l: number) => TypedArray} */
+        const BoxCtor = ArrayType;
+        /** @type {new(b: ArrayBufferLike, o: number, l: number) => Uint16Array | Uint32Array} */
+        const IdxCtor = this.IndexArrayType;
+
+        if (data) {
+            this.data = data;
+            this._boxes = new BoxCtor(data, byteOffset + 8, numNodes * 4);
+            //@ts-ignore
+            this._indices = new IdxCtor(data, byteOffset + 8 + nodesByteSize, numNodes);
+
+            this._pos = numNodes * 4;
+            this.minX = this._boxes[this._pos - 4];
+            this.minY = this._boxes[this._pos - 3];
+            this.maxX = this._boxes[this._pos - 2];
+            this.maxY = this._boxes[this._pos - 1];
+
+        } else {
+            const data = this.data = new ArrayBufferType(8 + nodesByteSize + numNodes * this.IndexArrayType.BYTES_PER_ELEMENT);
+            this._boxes = new BoxCtor(data, 8, numNodes * 4);
+            this._indices = new IdxCtor(data, 8 + nodesByteSize, numNodes);
+            this._pos = 0;
+            this.minX = Infinity;
+            this.minY = Infinity;
+            this.maxX = -Infinity;
+            this.maxY = -Infinity;
+
+            new Uint8Array(data, 0, 2).set([0xfb, (VERSION << 4) + arrayTypeIndex]);
+            new Uint16Array(data, 2, 1)[0] = nodeSize;
+            new Uint32Array(data, 4, 1)[0] = numItems;
+        }
+
+        // a priority queue for k-nearest-neighbors queries
+        /** @type FlatQueue<number> */
+        this._queue = new FlatQueue();
+    }
+
+    /**
+     * Add a given rectangle to the index.
+     * @param {number} minX
+     * @param {number} minY
+     * @param {number} maxX
+     * @param {number} maxY
+     * @returns {number} A zero-based, incremental number that represents the newly added rectangle.
+     */
+    add(minX: number, minY: number, maxX = minX, maxY = minY) {
+        const pos = this._pos;
+        const index = pos >> 2;
+        const boxes = this._boxes;
+        this._indices[index] = index;
+        boxes[pos] = minX;
+        boxes[pos + 1] = minY;
+        boxes[pos + 2] = maxX;
+        boxes[pos + 3] = maxY;
+        this._pos = pos + 4;
+
+        if (minX < this.minX) this.minX = minX;
+        if (minY < this.minY) this.minY = minY;
+        if (maxX > this.maxX) this.maxX = maxX;
+        if (maxY > this.maxY) this.maxY = maxY;
+
+        return index;
+    }
+
+    /** Perform indexing of the added rectangles. */
+    finish() {
+        if (this._pos >> 2 !== this.numItems) {
+            throw new Error(`Added ${this._pos >> 2} items when expected ${this.numItems}.`);
+        }
+        const boxes = this._boxes;
+
+        if (this.numItems <= this.nodeSize) {
+            // only one node, skip sorting and just fill the root box
+            boxes[this._pos++] = this.minX;
+            boxes[this._pos++] = this.minY;
+            boxes[this._pos++] = this.maxX;
+            boxes[this._pos++] = this.maxY;
+            return;
+        }
+
+        const { numItems, minX, minY, nodeSize, _indices: indices, _levelBounds: levelBounds } = this;
+        const width = (this.maxX - minX) || 1;
+        const height = (this.maxY - minY) || 1;
+        const hilbertValues = new Int32Array(numItems);
+        const hilbertMax = (1 << 16) - 1;
+        const sx = hilbertMax / width;
+        const sy = hilbertMax / height;
+
+        // map item centers into Hilbert coordinate space and calculate Hilbert values
+        for (let i = 0, pos = 0; i < numItems; i++) {
+            const itemMinX = boxes[pos++];
+            const itemMinY = boxes[pos++];
+            const itemMaxX = boxes[pos++];
+            const itemMaxY = boxes[pos++];
+            const x = (sx * ((itemMinX + itemMaxX) / 2 - minX)) | 0;
+            const y = (sy * ((itemMinY + itemMaxY) / 2 - minY)) | 0;
+            hilbertValues[i] = hilbert(x, y);
+        }
+
+        // sort items by their Hilbert value (for packing later)
+        //@ts-ignore
+        sort(hilbertValues, boxes, indices, 0, numItems - 1, nodeSize);
+
+        // generate nodes at each tree level, bottom-up
+        let pos = numItems * 4;
+        for (let i = 0, readPos = 0; i < levelBounds.length - 1; i++) {
+            const end = levelBounds[i];
+
+            // generate a parent node for each block of consecutive <nodeSize> nodes
+            while (readPos < end) {
+                const nodeIndex = readPos;
+
+                // calculate bbox for the new node
+                let nodeMinX = boxes[readPos++];
+                let nodeMinY = boxes[readPos++];
+                let nodeMaxX = boxes[readPos++];
+                let nodeMaxY = boxes[readPos++];
+                for (let j = 1; j < nodeSize && readPos < end; j++) {
+                    nodeMinX = Math.min(nodeMinX, boxes[readPos++]);
+                    nodeMinY = Math.min(nodeMinY, boxes[readPos++]);
+                    nodeMaxX = Math.max(nodeMaxX, boxes[readPos++]);
+                    nodeMaxY = Math.max(nodeMaxY, boxes[readPos++]);
+                }
+
+                // add the new node to the tree data
+                indices[pos >> 2] = nodeIndex;
+                boxes[pos++] = nodeMinX;
+                boxes[pos++] = nodeMinY;
+                boxes[pos++] = nodeMaxX;
+                boxes[pos++] = nodeMaxY;
+            }
+        }
+        this._pos = pos;
+    }
+
+    /**
+     * Search the index by a bounding box.
+     * @param {number} minX
+     * @param {number} minY
+     * @param {number} maxX
+     * @param {number} maxY
+     * @param {(index: number, x0: number, y0: number, x1: number, y1: number) => boolean} [filterFn] An optional function that is called on every found item; if supplied, only items for which this function returns true will be included in the results array.
+     * @returns {number[]} An array of indices of items intersecting or touching the given bounding box.
+     */
+    search(minX: number, minY: number, maxX: number, maxY: number, filterFn: (index: number, x0: number, y0: number, x1: number, y1: number) => boolean) {
+        if (this._pos !== this._boxes.length) {
+            throw new Error('Data not yet indexed - call index.finish().');
+        }
+        const { _boxes: boxes, _levelBounds: levelBounds, _indices: indices, nodeSize } = this;
+        const numItems4 = this.numItems * 4;
+
+        /** @type number | undefined */
+        let nodeIndex = boxes.length - 4;
+        let level = levelBounds.length - 1; // start at the root level
+        const q = [];
+        const results = [];
+
+        let contained = false; // whether the current node's bbox is fully inside the query
+
+        while (nodeIndex !== undefined) {
+            // find the end index of the node, capped at the level boundary
+            const end = Math.min(nodeIndex + nodeSize * 4, levelBounds[level]);
+            const isNode = nodeIndex >= numItems4;
+
+            if (contained) {
+                this._collectContained(nodeIndex, end, level, numItems4, results, filterFn);
+
+            } else {
+                // search through child nodes
+                for (let /** @type {number} */ pos = nodeIndex; pos < end; pos += 4) {
+                    // check if node bbox intersects with query bbox
+                    const x0 = boxes[pos];
+                    if (maxX < x0) continue;
+                    const y0 = boxes[pos + 1];
+                    if (maxY < y0) continue;
+                    const x1 = boxes[pos + 2];
+                    if (minX > x1) continue;
+                    const y1 = boxes[pos + 3];
+                    if (minY > y1) continue;
+
+                    const index = indices[pos >> 2] | 0;
+
+                    if (isNode) {
+                        // node intersects; flag it as contained if its bbox is fully inside the query
+                        const c = +(minX <= x0 && minY <= y0 && maxX >= x1 && maxY >= y1);
+                        q.push(index | c, level - 1); // node; add it and its level to the search queue
+
+                    } else if (filterFn === undefined || filterFn(index, x0, y0, x1, y1)) {
+                        results.push(index); // leaf item
+                    }
+                }
+            }
+
+            level = q.pop() as number;
+            nodeIndex = q.pop() as number;
+            if (nodeIndex !== undefined) {
+                contained = (nodeIndex & 1) === 1;
+                nodeIndex &= ~1;
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Collect all leaves of a subtree that's fully inside the query, skipping intersection tests.
+     * Because the tree is packed bottom-up, those leaves occupy one contiguous block of the leaf
+     * level, so we skip traversal entirely: descend to the first leaf, then sweep the flat range.
+     * @param {number} nodeIndex
+     * @param {number} end
+     * @param {number} level
+     * @param {number} numItems4
+     * @param {number[]} results
+     * @param {((index: number, x0: number, y0: number, x1: number, y1: number) => boolean) | undefined} filterFn
+     */
+    _collectContained(nodeIndex: number, end: number, level: number, numItems4: number, results: Array<number>, filterFn : ((index: number, x0: number, y0: number, x1: number, y1: number) => boolean) | undefined) {
+        const boxes = this._boxes;
+        const indices = this._indices;
+        let pos = nodeIndex;
+        for (let l = level; l > 0; l--) pos = indices[pos >> 2];
+        const leafEnd = Math.min(pos + (end - nodeIndex) * this.nodeSize ** level, numItems4);
+        if (filterFn === undefined) {
+            for (; pos < leafEnd; pos += 4) results.push(indices[pos >> 2] | 0);
+        } else {
+            for (; pos < leafEnd; pos += 4) {
+                const index = indices[pos >> 2] | 0;
+                if (filterFn(index, boxes[pos], boxes[pos + 1], boxes[pos + 2], boxes[pos + 3])) results.push(index);
+            }
+        }
+    }
+
+    /**
+     * Search items in order of distance from the given point.
+     * @param {number} x
+     * @param {number} y
+     * @param {number} [maxResults=Infinity]
+     * @param {number} [maxDistance=Infinity]
+     * @param {(index: number) => boolean} [filterFn] An optional function for filtering the results.
+     * @returns {number[]} An array of indices of items found.
+     */
+    neighbors(x: number, y: number, maxResults = Infinity, maxDistance = Infinity, filterFn?: ((index: number) => boolean | undefined)) {
+        if (this._pos !== this._boxes.length) {
+            throw new Error('Data not yet indexed - call index.finish().');
+        }
+        const { _boxes: boxes, _levelBounds: levelBounds, _indices: indices, _queue: q, nodeSize } = this;
+        const numItems4 = this.numItems * 4;
+        const nodeSize4 = nodeSize * 4;
+        const results = [];
+        const maxDistSquared = maxDistance * maxDistance;
+
+        // For a single nearest neighbor (maxResults === 1), track the closest leaf seen so far and use
+        // it as a tightened distance bound, skipping pushes of nodes/leaves that can't beat it
+        const trackNearest = maxResults === 1;
+        let bound = maxDistSquared;
+
+        // Tree nodes and leaves share the queue; encode leaves with LSB = 1 so we can tell them
+        // apart with `& 1`. Seed with the root node — any priority works since the queue is empty.
+        q.push((boxes.length - 4) << 1, 0);
+
+        while (q.length) {
+            const top = q.ids[0];
+            // if the closest queued entry is a leaf, it's the next result in distance order
+            if (top & 1) {
+                q.pop();
+                results.push(top >> 1);
+                if (results.length === maxResults) break;
+                continue;
+            }
+
+            q.pop();
+            const nodeIndex = top >> 1;
+            const isLeafLevel = nodeIndex < numItems4;
+            const end = Math.min(nodeIndex + nodeSize4, upperBound(nodeIndex, levelBounds));
+
+            for (let pos = nodeIndex; pos < end; pos += 4) {
+                const minX = boxes[pos];
+                const minY = boxes[pos + 1];
+                const maxX = boxes[pos + 2];
+                const maxY = boxes[pos + 3];
+                const dx = Math.max(Math.max(minX - x, x - maxX), 0);
+                const dy = Math.max(Math.max(minY - y, y - maxY), 0);
+                const dist = dx * dx + dy * dy;
+                if (dist > bound) continue;
+
+                const childIndex = indices[pos >> 2] | 0;
+                if (isLeafLevel) {
+                    if (filterFn === undefined || filterFn(childIndex)) {
+                        q.push((childIndex << 1) | 1, dist); // leaf item (odd id)
+                        if (trackNearest && dist < bound) bound = dist; // tighten bound to the closest leaf so far
+                    }
+                } else {
+                    q.push(childIndex << 1, dist); // node (even id)
+                }
+            }
+        }
+
+        q.clear();
+        return results;
+    }
+}
+
+/**
+ * Binary search for the first value in the array bigger than the given.
+ * @param {number} value
+ * @param {number[]} arr
+ */
+function upperBound(value: number, arr: number[]) {
+    let i = 0;
+    let j = arr.length - 1;
+    while (i < j) {
+        const m = (i + j) >> 1;
+        if (arr[m] > value) {
+            j = m;
+        } else {
+            i = m + 1;
+        }
+    }
+    return arr[i];
+}
+
+/**
+ * Custom quicksort that partially sorts bbox data alongside the hilbert values.
+ * @param {Int32Array} values
+ * @param {TypedArray} boxes
+ * @param {Uint16Array | Uint32Array} indices
+ * @param {number} left
+ * @param {number} right
+ * @param {number} nodeSize
+ */
+function sort(values: Int32Array, boxes: TypedArray, indices: Uint16Array, left: number, right: number, nodeSize: number) {
+    const stack = [left, right];
+
+    while (stack.length) {
+        const r = stack.pop() || 0;
+        const l = stack.pop() || 0;
+
+        if (r - l <= nodeSize && Math.floor(l / nodeSize) >= Math.floor(r / nodeSize)) continue;
+
+        const a = values[l];
+        const b = values[(l + r) >> 1];
+        const c = values[r];
+        const pivot = ((a > b) !== (a > c)) ? a :
+            ((b < a) !== (b < c)) ? b : c;
+
+        let i = l - 1;
+        let j = r + 1;
+
+        while (true) {
+            do i++; while (values[i] < pivot);
+            do j--; while (values[j] > pivot);
+            if (i >= j) break;
+            swap(values, boxes, indices, i, j);
+        }
+
+        stack.push(l, j, j + 1, r);
+    }
+}
+
+/**
+ * Swap two values and two corresponding boxes.
+ * @param {Int32Array} values
+ * @param {TypedArray} boxes
+ * @param {Uint16Array | Uint32Array} indices
+ * @param {number} i
+ * @param {number} j
+ */
+function swap(values: Int32Array, boxes: TypedArray, indices: Uint16Array | Uint32Array, i: number, j: number) {
+    const temp = values[i];
+    values[i] = values[j];
+    values[j] = temp;
+
+    const k = 4 * i;
+    const m = 4 * j;
+
+    const a = boxes[k];
+    const b = boxes[k + 1];
+    const c = boxes[k + 2];
+    const d = boxes[k + 3];
+    boxes[k] = boxes[m];
+    boxes[k + 1] = boxes[m + 1];
+    boxes[k + 2] = boxes[m + 2];
+    boxes[k + 3] = boxes[m + 3];
+    boxes[m] = a;
+    boxes[m + 1] = b;
+    boxes[m + 2] = c;
+    boxes[m + 3] = d;
+
+    const e = indices[i];
+    indices[i] = indices[j];
+    indices[j] = e;
+}
+
+/**
+ * Fast Hilbert curve algorithm by http://threadlocalmutex.com/
+ * Ported from C++ https://github.com/rawrunprotected/hilbert_curves (public domain)
+ * @param {number} x
+ * @param {number} y
+ */
+function hilbert(x: number, y: number) {
+    let a = x ^ y;
+    let b = 0xFFFF ^ a;
+    let c = 0xFFFF ^ (x | y);
+    let d = x & (y ^ 0xFFFF);
+
+    let A = a | (b >> 1);
+    let B = (a >> 1) ^ a;
+    let C = c ^ ((c >> 1) ^ (b & (d >> 1)));
+    let D = d ^ ((a & (c >> 1)) ^ (d >> 1));
+
+    a = (A & (A >> 2)) ^ (B & (B >> 2));
+    b = (A & (B >> 2)) ^ (B & ((A ^ B) >> 2));
+    c = C ^ ((A & (C >> 2)) ^ (B & (D >> 2)));
+    d = D ^ ((B & (C >> 2)) ^ ((A ^ B) & (D >> 2)));
+
+    A = (a & (a >> 4)) ^ (b & (b >> 4));
+    B = (a & (b >> 4)) ^ (b & ((a ^ b) >> 4));
+    C = c ^ ((a & (c >> 4)) ^ (b & (d >> 4)));
+    D = d ^ ((b & (c >> 4)) ^ ((a ^ b) & (d >> 4)));
+
+    c = C ^ ((A & (C >> 8)) ^ (B & (D >> 8)));
+    d = D ^ ((B & (C >> 8)) ^ ((A ^ B) & (D >> 8)));
+
+    c ^= c >> 1;
+    d ^= d >> 1;
+    a = x ^ y;
+    b = d | (0xFFFF ^ (a | c));
+
+    a = (a | (a << 8)) & 0x00FF00FF;
+    a = (a | (a << 4)) & 0x0F0F0F0F;
+    a = (a | (a << 2)) & 0x33333333;
+    a = (a | (a << 1)) & 0x55555555;
+
+    b = (b | (b << 8)) & 0x00FF00FF;
+    b = (b | (b << 4)) & 0x0F0F0F0F;
+    b = (b | (b << 2)) & 0x33333333;
+    b = (b | (b << 1)) & 0x55555555;
+
+    // shift into signed SMI range for performance
+    return (((b << 1) | a) >>> 0) - 0x80000000;
+}

--- a/lib/FlatQueue.ts
+++ b/lib/FlatQueue.ts
@@ -1,0 +1,153 @@
+/*
+
+ISC License
+
+Copyright (c) 2025, Volodymyr Agafonkin
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+*/
+
+/**
+ * @typedef {Float64ArrayConstructor | Float32ArrayConstructor |
+ *   Uint32ArrayConstructor | Int32ArrayConstructor | Uint16ArrayConstructor |
+ *   Int16ArrayConstructor | Uint8ArrayConstructor | Int8ArrayConstructor} TypedArrayConstructor
+ */
+
+/** @template [T=number] */
+export default class FlatQueue {
+
+    /**
+     * Creates an empty queue. If `capacity` is provided, the queue is backed by fixed-size typed
+     * arrays for better performance and memory use, but can't grow beyond `capacity`. `values` uses
+     * `ValuesArray` (default `Float64Array`) and `ids` uses `IdsArray` (default `Uint32Array`); pass
+     * narrower constructors like `Uint16Array` if your values or ids are known to fit them.
+     *
+     * @param {number} [capacity]
+     * @param {TypedArrayConstructor} [ValuesArray]
+     * @param {TypedArrayConstructor} [IdsArray]
+     */
+    ids;
+    values;
+    capacity: number;
+    length: number;
+    constructor(capacity = Infinity, ValuesArray = Float64Array, IdsArray = Uint32Array) {
+        const fixed = capacity !== Infinity;
+
+        /** @type {T[]} */
+        this.ids = fixed ? /** @type {T[]} */ (/** @type {unknown} */ (new IdsArray(capacity))) : [];
+
+        /** @type {number[]} */
+        this.values = fixed ? /** @type {number[]} */ (/** @type {unknown} */ (new ValuesArray(capacity))) : [];
+
+        /** Maximum number of items the queue can hold; `Infinity` for regular-array queues, which grow on demand. */
+        this.capacity = capacity;
+
+        /** Number of items in the queue. */
+        this.length = 0;
+    }
+
+    /** Removes all items from the queue. */
+    clear() {
+        this.length = 0;
+    }
+
+    /**
+     * Adds `item` to the queue with the specified `priority`.
+     *
+     * `priority` must be a number. Items are sorted and returned from low to high priority. Multiple items
+     * with the same priority value can be added to the queue, but there is no guaranteed order between these items.
+     *
+     * For fixed-capacity queues, throws a `RangeError` if the queue is already full.
+     *
+     * @param {T} item
+     * @param {number} priority
+     */
+    push(item: any, priority: number) {
+        if (this.length === this.capacity) throw new RangeError('Queue is at capacity.');
+
+        let pos = this.length++;
+
+        while (pos > 0) {
+            const parent = (pos - 1) >> 1;
+            const parentValue = this.values[parent];
+            if (priority >= parentValue) break;
+            this.ids[pos] = this.ids[parent];
+            this.values[pos] = parentValue;
+            pos = parent;
+        }
+
+        this.ids[pos] = item;
+        this.values[pos] = priority;
+    }
+
+    /**
+     * Removes and returns the item from the head of this queue, which is one of
+     * the items with the lowest priority. If this queue is empty, returns `undefined`.
+     */
+    pop() {
+        if (this.length === 0) return undefined;
+
+        const ids = this.ids,
+            values = this.values,
+            top = ids[0],
+            last = --this.length;
+
+        if (last > 0) {
+            const id = ids[last];
+            const value = values[last];
+            let pos = 0;
+            const halfLen = last >> 1;
+
+            while (pos < halfLen) {
+                const left = (pos << 1) + 1;
+                const right = left + 1;
+                const child = left + (+(right < last) & +(values[right] < values[left]));
+                if (values[child] >= value) break;
+                ids[pos] = ids[child];
+                values[pos] = values[child];
+                pos = child;
+            }
+
+            ids[pos] = id;
+            values[pos] = value;
+        }
+
+        return top;
+    }
+
+    /** Returns the item from the head of this queue without removing it. If this queue is empty, returns `undefined`. */
+    peek() {
+        return this.length > 0 ? this.ids[0] : undefined;
+    }
+
+    /**
+     * Returns the priority value of the item at the head of this queue without
+     * removing it. If this queue is empty, returns `undefined`.
+     */
+    peekValue() {
+        return this.length > 0 ? this.values[0] : undefined;
+    }
+
+    /**
+     * Shrinks the internal arrays to `this.length`. No-op for queues with fixed capacity.
+     *
+     * `pop()` and `clear()` calls don't free memory automatically to avoid unnecessary resize operations.
+     * This also means that items that have been added to the queue can't be garbage collected until
+     * a new item is pushed in their place, or this method is called.
+     */
+    shrink() {
+        if (Array.isArray(this.ids)) this.ids.length = this.length;
+        if (Array.isArray(this.values)) this.values.length = this.length;
+    }
+}

--- a/lib/KDBush.ts
+++ b/lib/KDBush.ts
@@ -1,0 +1,391 @@
+/*
+
+ISC License
+
+Copyright (c) 2026, Vladimir Agafonkin
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+*/
+
+const ARRAY_TYPES = [
+    Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Float32Array, Float64Array
+];
+export type TypedArrayConstructor = Int8ArrayConstructor | Uint8ArrayConstructor | Uint8ClampedArrayConstructor | Int16ArrayConstructor | Uint16ArrayConstructor | Int32ArrayConstructor | Uint32ArrayConstructor | Float32ArrayConstructor | Float64ArrayConstructor;
+export type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
+
+const VERSION = 1; // serialized format version
+const HEADER_SIZE = 8;
+
+// Shared scratch stack for iterative DFS in range/within. Sized for the worst case:
+// 3 ints per frame * (treeHeight + 1), with treeHeight ≤ ceil(log2(2^32 / 3)) ≈ 31.
+const STACK = new Uint32Array(96);
+
+export default class KDBush {
+    numItems: number;
+    nodeSize: number;
+    ArrayType: TypedArrayConstructor;
+    IndexArrayType
+    data: ArrayBufferLike;
+    _pos: number;
+    _finished: boolean;
+    ids;
+    coords;
+
+    /**
+     * Creates an index from raw `ArrayBuffer` data.
+     * @param {ArrayBufferLike} data
+     */
+    static from(data: ArrayBufferLike) {
+        //@ts-ignore
+        if (!data || data.byteLength === undefined || data.buffer) {
+            throw new Error('Data must be an instance of ArrayBuffer or SharedArrayBuffer.');
+        }
+        const [magic, versionAndType] = new Uint8Array(data, 0, 2);
+        if (magic !== 0xdb) {
+            throw new Error('Data does not appear to be in a KDBush format.');
+        }
+        const version = versionAndType >> 4;
+        if (version !== VERSION) {
+            throw new Error(`Got v${version} data when expected v${VERSION}.`);
+        }
+        const ArrayType = ARRAY_TYPES[versionAndType & 0x0f];
+        if (!ArrayType) {
+            throw new Error('Unrecognized array type.');
+        }
+        const [nodeSize] = new Uint16Array(data, 2, 1);
+        const [numItems] = new Uint32Array(data, 4, 1);
+        //@ts-ignore
+        return new KDBush(numItems, nodeSize, ArrayType, undefined, data);
+    }
+
+    /**
+     * Creates an index that will hold a given number of items.
+     * @param {number} numItems
+     * @param {number} [nodeSize=64] Size of the KD-tree node (64 by default).
+     * @param {TypedArrayConstructor} [ArrayType=Float64Array] The array type used for coordinates storage (`Float64Array` by default).
+     * @param {ArrayBufferConstructor | SharedArrayBufferConstructor} [ArrayBufferType=ArrayBuffer] The array buffer type used for storage (`ArrayBuffer` by default).
+     * @param {ArrayBufferLike} [data] (For internal use only)
+     */
+    constructor(numItems: number, nodeSize: number | undefined = 64, 
+        ArrayType: Float64ArrayConstructor | undefined = Float64Array, 
+        ArrayBufferType: ArrayBufferConstructor | SharedArrayBufferConstructor | undefined = ArrayBuffer, data: ArrayBufferLike | undefined) {
+        if (isNaN(numItems) || numItems < 0) throw new Error(`Unexpected numItems value: ${numItems}.`);
+
+        this.numItems = +numItems;
+        this.nodeSize = Math.min(Math.max(+nodeSize, 2), 65535);
+        this.ArrayType = ArrayType;
+
+        this.IndexArrayType = numItems < 65536 ? Uint16Array : Uint32Array;
+
+        const arrayTypeIndex = ARRAY_TYPES.indexOf(this.ArrayType);
+        const coordsByteSize = numItems * 2 * this.ArrayType.BYTES_PER_ELEMENT;
+
+        const idsByteSize = numItems * this.IndexArrayType.BYTES_PER_ELEMENT;
+        const padCoords = (8 - idsByteSize % 8) % 8;
+
+        if (arrayTypeIndex < 0) {
+            throw new Error(`Unexpected typed array class: ${ArrayType}.`);
+        }
+
+        if (data) { // reconstruct an index from a buffer
+            this.data = data;
+            // @ts-expect-error TS can't handle SharedArrayBuffer overloads
+            this.ids = new this.IndexArrayType(data, HEADER_SIZE, numItems);
+            this.coords = new ArrayType(data, HEADER_SIZE + idsByteSize + padCoords, numItems * 2);
+            this._pos = numItems * 2;
+            this._finished = true;
+
+        } else { // initialize a new index
+            const data = this.data = new ArrayBufferType(HEADER_SIZE + coordsByteSize + idsByteSize + padCoords);
+            // @ts-expect-error TS can't handle SharedArrayBuffer overloads
+            this.ids = new this.IndexArrayType(data, HEADER_SIZE, numItems);
+            this.coords = new ArrayType(data, HEADER_SIZE + idsByteSize + padCoords, numItems * 2);
+            this._pos = 0;
+            this._finished = false;
+
+            // set header
+            new Uint8Array(data, 0, 2).set([0xdb, (VERSION << 4) + arrayTypeIndex]);
+            new Uint16Array(data, 2, 1)[0] = nodeSize;
+            new Uint32Array(data, 4, 1)[0] = numItems;
+        }
+    }
+
+    /**
+     * Add a point to the index.
+     * @param {number} x
+     * @param {number} y
+     * @returns {number} An incremental index associated with the added item (starting from `0`).
+     */
+    add(x: number, y: number): number {
+        const index = this._pos >> 1;
+        this.ids[index] = index;
+        this.coords[this._pos++] = x;
+        this.coords[this._pos++] = y;
+        return index;
+    }
+
+    /**
+     * Perform indexing of the added points.
+     */
+    finish() {
+        const numAdded = this._pos >> 1;
+        if (numAdded !== this.numItems) {
+            throw new Error(`Added ${numAdded} items when expected ${this.numItems}.`);
+        }
+        // kd-sort both arrays for efficient search
+
+        sort(this.ids, this.coords, this.nodeSize, 0, this.numItems - 1, 0);
+
+        this._finished = true;
+        return this;
+    }
+
+    /**
+     * Search the index for items within a given bounding box.
+     * @param {number} minX
+     * @param {number} minY
+     * @param {number} maxX
+     * @param {number} maxY
+     * @returns {number[]} An array of indices correponding to the found items.
+     */
+    range(minX: number, minY: number, maxX: number, maxY: number) {
+        if (!this._finished) throw new Error('Data not yet indexed - call index.finish().');
+
+        const { ids, coords, nodeSize } = this;
+        STACK[0] = 0;
+        STACK[1] = ids.length - 1;
+        STACK[2] = 0;
+        let sp = 3;
+        const result = [];
+
+        // recursively search for items in range in the kd-sorted arrays
+        while (sp > 0) {
+            const axis = STACK[--sp];
+            const right = STACK[--sp];
+            const left = STACK[--sp];
+
+            // if we reached "tree node", search linearly
+            if (right - left <= nodeSize) {
+                for (let i = left; i <= right; i++) {
+                    const x = coords[2 * i];
+                    const y = coords[2 * i + 1];
+                    if (x >= minX && x <= maxX && y >= minY && y <= maxY) result.push(ids[i]);
+                }
+                continue;
+            }
+
+            // otherwise find the middle index
+            const m = (left + right) >> 1;
+
+            // include the middle item if it's in range
+            const x = coords[2 * m];
+            const y = coords[2 * m + 1];
+            if (x >= minX && x <= maxX && y >= minY && y <= maxY) result.push(ids[m]);
+
+            // queue search in halves that intersect the query
+            if (axis === 0 ? minX <= x : minY <= y) {
+                STACK[sp++] = left;
+                STACK[sp++] = m - 1;
+                STACK[sp++] = 1 - axis;
+            }
+            if (axis === 0 ? maxX >= x : maxY >= y) {
+                STACK[sp++] = m + 1;
+                STACK[sp++] = right;
+                STACK[sp++] = 1 - axis;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Search the index for items within a given radius.
+     * @param {number} qx
+     * @param {number} qy
+     * @param {number} r Query radius.
+     * @returns {number[]} An array of indices correponding to the found items.
+     */
+    within(qx: number, qy: number, r: number) {
+        const result: number[] = ([]);
+        this.withinInto(qx, qy, r, result);
+        return result;
+    }
+
+    /**
+     * Search the index for items within a given radius, writing matching ids into `out`
+     * via indexed assignment (`out[i] = id`). Accepts any indexed-writable container —
+     * a typed array sized to the expected upper bound (allocation-free, fast) or a plain
+     * `Array` (which will grow as needed). Returns the number of matches written.
+     * @param {number} qx
+     * @param {number} qy
+     * @param {number} r Query radius.
+     * @param {number[] | TypedArray} out Container to write matching ids into.
+     * @returns {number} The number of matches written to `out`.
+     */
+    withinInto(qx: number, qy: number, r: number, out: number[] | TypedArray) {
+        if (!this._finished) throw new Error('Data not yet indexed - call index.finish().');
+
+        const { ids, coords, nodeSize } = this;
+        STACK[0] = 0;
+        STACK[1] = ids.length - 1;
+        STACK[2] = 0;
+        let sp = 3;
+        let count = 0;
+        const r2 = r * r;
+
+        // recursively search for items within radius in the kd-sorted arrays
+        while (sp > 0) {
+            const axis = STACK[--sp];
+            const right = STACK[--sp];
+            const left = STACK[--sp];
+
+            // if we reached "tree node", search linearly
+            if (right - left <= nodeSize) {
+                for (let i = left; i <= right; i++) {
+                    if (sqDist(coords[2 * i], coords[2 * i + 1], qx, qy) <= r2) out[count++] = ids[i];
+                }
+                continue;
+            }
+
+            // otherwise find the middle index
+            const m = (left + right) >> 1;
+
+            // include the middle item if it's in range
+            const x = coords[2 * m];
+            const y = coords[2 * m + 1];
+            if (sqDist(x, y, qx, qy) <= r2) out[count++] = ids[m];
+
+            // queue search in halves that intersect the query
+            if (axis === 0 ? qx - r <= x : qy - r <= y) {
+                STACK[sp++] = left;
+                STACK[sp++] = m - 1;
+                STACK[sp++] = 1 - axis;
+            }
+            if (axis === 0 ? qx + r >= x : qy + r >= y) {
+                STACK[sp++] = m + 1;
+                STACK[sp++] = right;
+                STACK[sp++] = 1 - axis;
+            }
+        }
+
+        return count;
+    }
+}
+
+/**
+ * @param {Uint16Array | Uint32Array} ids
+ * @param {TypedArray} coords
+ * @param {number} nodeSize
+ * @param {number} left
+ * @param {number} right
+ * @param {number} axis
+ */
+function sort(ids: Uint16Array | Uint32Array, coords: TypedArray, nodeSize: number, left: number, right: number, axis: number) {
+    if (right - left <= nodeSize) return;
+
+    const m = (left + right) >> 1; // middle index
+
+    // sort ids and coords around the middle index so that the halves lie
+    // either left/right or top/bottom correspondingly (taking turns)
+    select(ids, coords, m, left, right, axis);
+
+    // recursively kd-sort first half and second half on the opposite axis
+    sort(ids, coords, nodeSize, left, m - 1, 1 - axis);
+    sort(ids, coords, nodeSize, m + 1, right, 1 - axis);
+}
+
+/**
+ * Custom Floyd-Rivest selection algorithm: sort ids and coords so that
+ * [left..k-1] items are smaller than k-th item (on either x or y axis)
+ * @param {Uint16Array | Uint32Array} ids
+ * @param {TypedArray} coords
+ * @param {number} k
+ * @param {number} left
+ * @param {number} right
+ * @param {number} axis
+ */
+function select(ids: Uint16Array | Uint32Array, coords: TypedArray, k: number, left: number, right: number, axis: number) {
+
+    while (right > left) {
+        if (right - left > 600) {
+            const n = right - left + 1;
+            const m = k - left + 1;
+            const z = Math.log(n);
+            const s = 0.5 * Math.exp(2 * z / 3);
+            const sd = 0.5 * Math.sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
+            const newLeft = Math.max(left, Math.floor(k - m * s / n + sd));
+            const newRight = Math.min(right, Math.floor(k + (n - m) * s / n + sd));
+            select(ids, coords, k, newLeft, newRight, axis);
+        }
+
+        const t = coords[2 * k + axis];
+        let i = left;
+        let j = right;
+
+        swapItem(ids, coords, left, k);
+        if (coords[2 * right + axis] > t) swapItem(ids, coords, left, right);
+
+        while (i < j) {
+            swapItem(ids, coords, i, j);
+            i++;
+            j--;
+            while (coords[2 * i + axis] < t) i++;
+            while (coords[2 * j + axis] > t) j--;
+        }
+
+        if (coords[2 * left + axis] === t) swapItem(ids, coords, left, j);
+        else {
+            j++;
+            swapItem(ids, coords, j, right);
+        }
+
+        if (j <= k) left = j + 1;
+        if (k <= j) right = j - 1;
+    }
+}
+
+/**
+ * @param {Uint16Array | Uint32Array} ids
+ * @param {TypedArray} coords
+ * @param {number} i
+ * @param {number} j
+ */
+function swapItem(ids: Uint16Array | Uint32Array, coords: TypedArray, i: number, j: number) {
+    swap(ids, i, j);
+    swap(coords, 2 * i, 2 * j);
+    swap(coords, 2 * i + 1, 2 * j + 1);
+}
+
+/**
+ * @param {TypedArray} arr
+ * @param {number} i
+ * @param {number} j
+ */
+function swap(arr: TypedArray, i: number, j: number) {
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+}
+
+/**
+ * @param {number} ax
+ * @param {number} ay
+ * @param {number} bx
+ * @param {number} by
+ */
+function sqDist(ax: number, ay: number, bx: number, by: number) {
+    const dx = ax - bx;
+    const dy = ay - by;
+    return dx * dx + dy * dy;
+}

--- a/lib/clustering.ts
+++ b/lib/clustering.ts
@@ -3,8 +3,8 @@ import makeHull from "./convexhull";
 import { FIZZSCAN } from "./FIZZSCAN";
 import Voronoi from "./rhill-voronoi-core";
 import polygonClipping from 'polygon-clipping'
-import KDBush from "kdbush";
-import Flatbush from "flatbush";
+import KDBush from "./KDBush";
+import Flatbush from "./FlatBush";
 
 export { generateClusterAnalysis, type clusterObject, type coord }
 
@@ -37,8 +37,8 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
     for (let i = 0; i < dataLength; i++) {
         dataArray.push([Number(data[i]["x"]), Number(data[i]["y"])]);
     }
-    const kdBush = new KDBush(dataArray.length);
-    const flatBush = new Flatbush(dataArray.length);
+    const kdBush = new KDBush(dataArray.length, undefined, undefined, undefined, undefined);
+    const flatBush = new Flatbush(dataArray.length, undefined, undefined, undefined, undefined);
     for (let point of dataArray) {
         kdBush.add(point[0], point[1]);
         flatBush.add(point[0], point[1]);
@@ -49,7 +49,7 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
     const distanceStorage: Array<Array<number>> = [];
 
     for (let i = 0; i < dataLength; i++) {
-        const flatTest = flatBush.neighbors(dataArray[i][0], dataArray[i][1], minPts * 2)
+        const flatTest = flatBush.neighbors(dataArray[i][0], dataArray[i][1], minPts * 2, undefined, undefined)
         distanceStorage.push(flatTest.map(j => euclidDistance(dataArray[i], dataArray[j])))
     }
     let sum = 0;

--- a/lib/clustering.ts
+++ b/lib/clustering.ts
@@ -3,6 +3,8 @@ import makeHull from "./convexhull";
 import { FIZZSCAN } from "./FIZZSCAN";
 import Voronoi from "./rhill-voronoi-core";
 import polygonClipping from 'polygon-clipping'
+import KDBush from "kdbush";
+import Flatbush from "flatbush";
 
 export { generateClusterAnalysis, type clusterObject, type coord }
 
@@ -33,25 +35,30 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
     const epsilonParameter = 2;
     const dataArray: Array<Pair> = [];
     for (let i = 0; i < dataLength; i++) {
-        dataArray.push([Number(data[i]["x"]), Number(data[i]["y"])])
+        dataArray.push([Number(data[i]["x"]), Number(data[i]["y"])]);
     }
+    const kdBush = new KDBush(dataArray.length);
+    const flatBush = new Flatbush(dataArray.length);
+    for (let point of dataArray) {
+        kdBush.add(point[0], point[1]);
+        flatBush.add(point[0], point[1]);
+    }
+    kdBush.finish();
+    flatBush.finish();
 
-    //distAvg averges out the nearest neighbor distances over each point in the set
-    const distAvg: Array<number> = [];
     const distanceStorage: Array<Array<number>> = [];
 
     for (let i = 0; i < dataLength; i++) {
-        distanceStorage.push(nNDistancesSpecial(dataArray, i, minPts))
+        const flatTest = flatBush.neighbors(dataArray[i][0], dataArray[i][1], minPts * 2)
+        distanceStorage.push(flatTest.map(j => euclidDistance(dataArray[i], dataArray[j])))
     }
-
+    let sum = 0;
     for (let i = 0; i < dataLength; i++) {
-        let sum: number = 0;
-        for (let j = 0; j < dataLength; j++) {
-            sum += distanceStorage[j][i];
-        }
-        distAvg.push(sum / dataLength);
+        sum += distanceStorage[i][minPts]
     }
-    const fizzscan = new FIZZSCAN(dataArray, epsilonParameter * distAvg[minPts], minPts, showForcing);
+    sum /= dataLength;
+
+    const fizzscan = new FIZZSCAN(dataArray, epsilonParameter * sum, minPts, showForcing, kdBush);
     let clusters = fizzscan.clusters
     let centroids = fizzscan.clusterCentroids;
     //let noise = fizzscan.noise;
@@ -230,20 +237,13 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
         masterArray[pair[1]].outlierIDs.push(pair[0])
     }
     //Adds density rankings for each cluster to masterArray
-    const masterArrayClone: Array<clusterObject> = JSON.parse(JSON.stringify(masterArray));
-    const densitySorted: Array<clusterObject> = masterArrayClone.sort((a, b) => {
-        return a.density - b.density;
-    })
-
-    const densityIDs: Array<number> = [];
-    for (let cluster of densitySorted) {
-        densityIDs.push(cluster.id);
-    }
+    const densityRanking = masterArray
+        .map((c, i) => ({ id: c.id, density: c.density, i }))
+        .sort((a, b) => a.density - b.density)
+        .map(c => c.id);
     for (let cluster of masterArray) {
-        cluster.densityRank = densityIDs.indexOf(cluster.id);
+        cluster.densityRank = densityRanking.indexOf(cluster.id);
     }
-
-
 
     //Designates "neighbors" of each cluster and adds to masterArray
     i = 0;
@@ -624,7 +624,7 @@ function findHoles(cluster: clusterObject): Array<hole> {
 
     const diagram = voronoi.compute(clusterData, bbox);
     const shell: Array<coord> = makeHull(clusterData)
-
+    const shellDecoord = deCoordinate(shell);
     const edgePoints: Array<Array<number>> = [];
     const verticesInside: Array<Array<number>> = [];
 
@@ -645,15 +645,15 @@ function findHoles(cluster: clusterObject): Array<hole> {
     }
 
     const epsilon: number = 10 ** (Math.log10(Math.max((cluster.xMax - cluster.xMin), (cluster.yMax - cluster.yMin))) - 4)
-
-    for (let point of deCoordinate(diagram.vertices)) {
-        if (classifyPoint(deCoordinate(shell), point, epsilon) < 1) {
+    const verticesDecoord = deCoordinate(diagram.vertices)
+    for (let point of verticesDecoord) {
+        if (classifyPoint(shellDecoord, point, epsilon) < 1) {
             verticesInside.push(point);
         }
     }
 
     for (let point of edgePoints) {
-        if (classifyPoint(deCoordinate(shell), point, epsilon) < 1) {
+        if (classifyPoint(shellDecoord, point, epsilon) < 1) {
             verticesInside.push(point);
         }
     }
@@ -662,10 +662,11 @@ function findHoles(cluster: clusterObject): Array<hole> {
 
     for (let vertexID = 0; vertexID < verticesInside.length; vertexID++) {
         let vertex: Array<number> = verticesInside[vertexID];
-        let min: Array<number> = [Number(vertexID), euclidDistance(vertex, deCoordinate(clusterData)[0])];
-        for (let point of deCoordinate(clusterData)) {
-            if (min[1] > euclidDistance(vertex, point)) {
-                min = [Number(vertexID), euclidDistance(vertex, point)]
+        let min: Array<number> = [Number(vertexID), euclidDistance(vertex, cluster.dataPoints[0])];
+        for (let point of cluster.dataPoints) {
+            const dist = euclidDistance(vertex, point);
+            if (min[1] > dist) {
+                min = [Number(vertexID), dist];
             }
         }
         minsArray.push(min);
@@ -674,7 +675,7 @@ function findHoles(cluster: clusterObject): Array<hole> {
     let sorted: Array<Array<number>> = minsArray.sort((a: number[], b: number[]) => { return b[1] - a[1] })
 
     //Culls similar holes by removing hole centers that lie within the border of a larger hole.
-    for (let pointID = 0; pointID <  sorted.length; pointID++) {
+    for (let pointID = 0; pointID < sorted.length; pointID++) {
         const point: Array<number> = sorted[pointID];
         let i: number = Number(pointID) + 1;
         while (i < sorted.length) {
@@ -731,7 +732,7 @@ function nNDistances(dataset: Array<Array<number>>, pointId: number): Array<numb
     return distances
 
 };
-
+/*
 function nNDistancesSpecial(dataset: Array<Array<number>>, pointId: number, minPts: number): Array<number> {
     //Returns list of distances from nearest neighbors for a point, sorted low to high.
     const distances: Array<number> = [];
@@ -742,7 +743,6 @@ function nNDistancesSpecial(dataset: Array<Array<number>>, pointId: number, minP
     if (minPts < 100) return partialSort(distances, 2 * minPts);
     else return Array.from(distances.sort((a, b) => { return a - b; }));
 };
-
 
 function bisect(items: Array<number>, x: number, lo?: number, hi?: number): number {
     let mid: number;
@@ -773,6 +773,7 @@ function partialSort(items: Array<number>, k: number): Array<number> {
     return smallest;
 }
 
+*/
 function nNIndices(dataset: Array<Array<number>>, pointId: number): Array<number> {
     //Returns list of nearest indices to a point, sorted low to high, including the point itself.
     let distances: Array<Array<number>> = [];

--- a/lib/clustering.ts
+++ b/lib/clustering.ts
@@ -11,21 +11,21 @@ export { generateClusterAnalysis, type clusterObject, type coord }
 
 function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: any[]) {
     //data.sort();
-    const dataLength: number = data.length
+    const dataLength: number = data.length;
 
     if (dataLength == 0) {
-        throw new Error("Error: Given data has zero length")
+        throw new Error("Error: Given data has zero length");
     }
     const factorizedLabels: any[] = [];
-    let labelPairs: Array<LabelFactorPair> = []
-    let uniqueLabels: Array<any> = []
+    let labelPairs: Array<LabelFactorPair> = [];
+    let uniqueLabels: Array<any> = [];
     if (labels != undefined) {
         if (dataLength != labels.length) {
-            throw new Error("Error: Given labels do not match length of data")
+            throw new Error("Error: Given labels do not match length of data");
         }
         uniqueLabels = [...new Set(labels.flat())]
         for (let i = 0; i < uniqueLabels.length; i++) {
-            labelPairs.push({ label: uniqueLabels[i], factor: i })
+            labelPairs.push({ label: uniqueLabels[i], factor: i });
         }
         for (let i = 0; i < labels.length; i++) {
             factorizedLabels.push(uniqueLabels.indexOf(labels[i]));
@@ -46,15 +46,16 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
     kdBush.finish();
     flatBush.finish();
 
+    const coordToIndex = new Map<string, number>()
     const distanceStorage: Array<Array<number>> = [];
-
-    for (let i = 0; i < dataLength; i++) {
-        const flatTest = flatBush.neighbors(dataArray[i][0], dataArray[i][1], minPts * 2, undefined, undefined)
-        distanceStorage.push(flatTest.map(j => euclidDistance(dataArray[i], dataArray[j])))
-    }
     let sum = 0;
     for (let i = 0; i < dataLength; i++) {
-        sum += distanceStorage[i][minPts]
+        const x = dataArray[i][0];
+        const y = dataArray[i][1];
+        const flatTest = flatBush.neighbors(x, y, minPts * 2, undefined, undefined);
+        distanceStorage.push(flatTest.map(j => euclidDistance(dataArray[i], dataArray[j])));
+        sum += distanceStorage[i][minPts];
+        coordToIndex.set(`${x},${y}`, i);
     }
     sum /= dataLength;
 
@@ -180,7 +181,11 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
         clusterObject.hull = hull;
 
         for (let point of hull) {
-            const id = dataArray.findIndex((e) => { return e[0] == point.x && e[1] == point.y })
+            //const id = dataArray.findIndex((e) => { return e[0] == point.x && e[1] == point.y })
+            let id = coordToIndex.get(`${point.x},${point.y}`)
+            if (!id) {
+                id = -1;
+            }
             clusterObject.hullIDs.push(id);
         }
 
@@ -203,7 +208,7 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
 
         clusterObject.relations = [];
         const closest: Array<number> = nNIndices(centroids, i);
-        const distances: Array<number> = nNDistances(centroids, i)
+        const distances: Array<number> = nNDistances(centroids, i);
 
         for (let j = 0; j < clusters.length; j++) {
             const angle: number = getAngle(centroids[i], centroids[closest[j]]);
@@ -219,7 +224,7 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
         clusterObject.holes = findHoles(clusterObject);
 
         const holeParameter = .2;
-        const largestHoleImportanceScore = clusterObject.holes[0][2]
+        const largestHoleImportanceScore = clusterObject.holes[0][2];
         if (largestHoleImportanceScore > holeParameter) {
             clusterObject.hasSignificantHole = true;
         }
@@ -233,8 +238,8 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
     }
     //Adds noise point IDs to each cluster in masterArray
     for (let pair of noiseAssigned) {
-        masterArray[pair[1]].outliers.push(dataArray[pair[0]])
-        masterArray[pair[1]].outlierIDs.push(pair[0])
+        masterArray[pair[1]].outliers.push(dataArray[pair[0]]);
+        masterArray[pair[1]].outlierIDs.push(pair[0]);
     }
     //Adds density rankings for each cluster to masterArray
     const densityRanking = masterArray
@@ -247,7 +252,7 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
 
     //Designates "neighbors" of each cluster and adds to masterArray
     i = 0;
-    const neighborParameter: number = 1.2
+    const neighborParameter: number = 1.2;
     for (let cluster of centroids) {
         let j: number = 0;
         for (let target of centroids) {
@@ -305,32 +310,32 @@ function generateClusterAnalysis(data: coord[], showForcing: boolean, labels?: a
         let cluster: clusterObject = masterArray[clusterId];
         for (let targetId = 0; targetId < masterArray.length; targetId++) {
             let pointer = 0;
-            for (let relationID = 0; relationID < masterArray[clusterId].relations.length; relationID++) {
-                let relation = masterArray[clusterId].relations[relationID]
+            for (let relationID = 0; relationID < cluster.relations.length; relationID++) {
+                let relation = cluster.relations[relationID]
                 if (relation.id == Number(targetId)) {
                     pointer = Number(relationID)
                 }
             }
             if (clusterId == targetId) {
-                masterArray[clusterId].relations[pointer].overlap = 1;
+                cluster.relations[pointer].overlap = 1;
             }
             else {
-                let target: clusterObject = masterArray[targetId];
-                let overlap = polygonClipping.intersection([deCoordinate(cluster.hull)], [deCoordinate(target.hull)]) as unknown as Array<Array<Array<Pair>>>;
+                const target: clusterObject = masterArray[targetId];
+                const overlap = polygonClipping.intersection([deCoordinate(cluster.hull)], [deCoordinate(target.hull)]) as unknown as Array<Array<Array<Pair>>>;
                 if (overlap.length > 0) {
                     let overlapPercentage = shoelace(coordinate(overlap[0][0])) / cluster.area;
-                    masterArray[clusterId].relations[pointer].overlap = overlapPercentage;
-                    masterArray[clusterId].relations[pointer].sharedPts = []
+                    cluster.relations[pointer].overlap = overlapPercentage;
+                    cluster.relations[pointer].sharedPts = [];
                     for (let point of cluster.dataPoints) {
                         let epsilon = 10 ** (Math.log10(Math.max((cluster.xMax - cluster.xMin), (cluster.yMax - cluster.yMin))) - 4)
                         if (classifyPoint(deCoordinate(target.hull), point, epsilon) < 1) {
-                            masterArray[clusterId].relations[pointer].sharedPts!.push(point);
+                            cluster.relations[pointer].sharedPts!.push(point);
                         }
                     }
-                    masterArray[clusterId].relations[pointer].percentPtsShared = masterArray[clusterId].relations[pointer].sharedPts!.length / masterArray[clusterId].dataPoints.length
+                    cluster.relations[pointer].percentPtsShared = cluster.relations[pointer].sharedPts!.length / cluster.dataPoints.length;
                 }
                 else {
-                    masterArray[clusterId].relations[pointer].overlap = 0;
+                    cluster.relations[pointer].overlap = 0;
                 }
             }
         }
@@ -519,7 +524,7 @@ function simplifyHull(inputShell: Array<coord>): Array<coord> {
     }
 
     //'Fills in' small edges near corners
-    const smallnessParameter = 20
+    const smallnessParameter = 20;
     const peri: number = perimeter(inputShell);
     for (let i = 0; i < n; i++) {
         if (euclidDistance(shell[(i + 1) % n], shell[(i + 2) % n]) < (peri / smallnessParameter)) {
@@ -575,10 +580,10 @@ function completeAngle(p1: coord | Array<number>, p2: coord | Array<number>, p3:
 function checkParallel(p1: coord | Array<number>, p2: coord | Array<number>, p3: coord | Array<number>, p4: coord | Array<number>): boolean {
     //Subfunction of completeAngle that is also useful to have as it's own function
     //Checks if the lines spanning p1-p2 and p3-p4 are parallel
-    if (!Array.isArray(p1)) { p1 = [p1.x, p1.y] }
-    if (!Array.isArray(p2)) { p2 = [p2.x, p2.y] }
-    if (!Array.isArray(p3)) { p3 = [p3.x, p3.y] }
-    if (!Array.isArray(p4)) { p4 = [p4.x, p4.y] }
+    if (!Array.isArray(p1)) { p1 = [p1.x, p1.y] };
+    if (!Array.isArray(p2)) { p2 = [p2.x, p2.y] };
+    if (!Array.isArray(p3)) { p3 = [p3.x, p3.y] };
+    if (!Array.isArray(p4)) { p4 = [p4.x, p4.y] };
 
     if ((p2[0] - p1[0]) == 0) {
         if ((p4[0] - p3[0]) == 0) {
@@ -659,8 +664,8 @@ function findHoles(cluster: clusterObject): Array<hole> {
     }
 
     let minsArray: Array<Array<number>> = [];
-
-    for (let vertexID = 0; vertexID < verticesInside.length; vertexID++) {
+    const verticesInsideLength = verticesInside.length;
+    for (let vertexID = 0; vertexID < verticesInsideLength; vertexID++) {
         let vertex: Array<number> = verticesInside[vertexID];
         let min: Array<number> = [Number(vertexID), euclidDistance(vertex, cluster.dataPoints[0])];
         for (let point of cluster.dataPoints) {
@@ -700,7 +705,8 @@ function findHoles(cluster: clusterObject): Array<hole> {
     }
 
     const closest: Array<hole> = []
-    for (let i = 0; i < sorted.length; i++) {
+    const sortedLength = sorted.length
+    for (let i = 0; i < sortedLength; i++) {
         const testHole: hole = [verticesInside[sorted[i][0]], sorted[i][1], 0]
         const centroidDistance = euclidDistance(testHole[0], cluster.centroid)
         const importanceScore = testHole[1] / avgDistance * (1 - centroidDistance / maxDistance)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "@fizz/clustering",
       "version": "0.16.0",
       "dependencies": {
-        "flatbush": "^4.6.2",
-        "kdbush": "^4.1.0",
         "polygon-clipping": "^0.15.7",
         "robust-point-in-polygon": "^1.0.3"
       },
@@ -917,21 +915,6 @@
         }
       }
     },
-    "node_modules/flatbush": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-4.6.2.tgz",
-      "integrity": "sha512-nNT7MFJ58Q4IAm3aYsEg+zgZGpdRcmR1i4U+aa8c+r91jmYZg7FTQwNnIMC0FyBqVZTbClKdAnrJkKkfp1BOvw==",
-      "license": "ISC",
-      "dependencies": {
-        "flatqueue": "^3.1.0"
-      }
-    },
-    "node_modules/flatqueue": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.1.0.tgz",
-      "integrity": "sha512-Ia4qIYrrsEqIRx3c3XhkT+QDLQuUV5ovsr6ah1rIgKT5wclhoGK3lAMS1bWRAWxlx7wtlTBpV7QXB5d9fOSRxA==",
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -946,12 +929,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/kdbush": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
-      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
-      "license": "ISC"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "@fizz/clustering",
       "version": "0.16.0",
       "dependencies": {
+        "flatbush": "^4.6.2",
+        "kdbush": "^4.1.0",
         "polygon-clipping": "^0.15.7",
         "robust-point-in-polygon": "^1.0.3"
       },
@@ -444,9 +446,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.37.0.tgz",
-      "integrity": "sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
       "cpu": [
         "arm"
       ],
@@ -458,9 +460,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.37.0.tgz",
-      "integrity": "sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
       "cpu": [
         "arm64"
       ],
@@ -472,9 +474,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.37.0.tgz",
-      "integrity": "sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
       "cpu": [
         "arm64"
       ],
@@ -486,9 +488,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.37.0.tgz",
-      "integrity": "sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
       "cpu": [
         "x64"
       ],
@@ -500,9 +502,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.37.0.tgz",
-      "integrity": "sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
       "cpu": [
         "arm64"
       ],
@@ -514,9 +516,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.37.0.tgz",
-      "integrity": "sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
       "cpu": [
         "x64"
       ],
@@ -528,13 +530,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.37.0.tgz",
-      "integrity": "sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -542,13 +547,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.37.0.tgz",
-      "integrity": "sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -556,13 +564,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.37.0.tgz",
-      "integrity": "sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,41 +581,84 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.37.0.tgz",
-      "integrity": "sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.37.0.tgz",
-      "integrity": "sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.37.0.tgz",
-      "integrity": "sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -612,13 +666,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.37.0.tgz",
-      "integrity": "sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -626,13 +683,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.37.0.tgz",
-      "integrity": "sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -640,13 +700,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.37.0.tgz",
-      "integrity": "sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -654,13 +717,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.37.0.tgz",
-      "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -668,9 +734,26 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.37.0.tgz",
-      "integrity": "sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
       "cpu": [
         "x64"
       ],
@@ -678,13 +761,27 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.37.0.tgz",
-      "integrity": "sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
       "cpu": [
         "arm64"
       ],
@@ -696,9 +793,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.37.0.tgz",
-      "integrity": "sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
       "cpu": [
         "ia32"
       ],
@@ -709,10 +806,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.37.0.tgz",
-      "integrity": "sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
       "cpu": [
         "x64"
       ],
@@ -724,9 +835,9 @@
       ]
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -806,6 +917,21 @@
         }
       }
     },
+    "node_modules/flatbush": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-4.6.2.tgz",
+      "integrity": "sha512-nNT7MFJ58Q4IAm3aYsEg+zgZGpdRcmR1i4U+aa8c+r91jmYZg7FTQwNnIMC0FyBqVZTbClKdAnrJkKkfp1BOvw==",
+      "license": "ISC",
+      "dependencies": {
+        "flatqueue": "^3.1.0"
+      }
+    },
+    "node_modules/flatqueue": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.1.0.tgz",
+      "integrity": "sha512-Ia4qIYrrsEqIRx3c3XhkT+QDLQuUV5ovsr6ah1rIgKT5wclhoGK3lAMS1bWRAWxlx7wtlTBpV7QXB5d9fOSRxA==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -821,10 +947,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
+    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -855,9 +987,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -878,9 +1010,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -898,7 +1030,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -956,13 +1088,13 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
-      "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.6"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -972,26 +1104,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.37.0",
-        "@rollup/rollup-android-arm64": "4.37.0",
-        "@rollup/rollup-darwin-arm64": "4.37.0",
-        "@rollup/rollup-darwin-x64": "4.37.0",
-        "@rollup/rollup-freebsd-arm64": "4.37.0",
-        "@rollup/rollup-freebsd-x64": "4.37.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.37.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.37.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.37.0",
-        "@rollup/rollup-linux-arm64-musl": "4.37.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.37.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.37.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.37.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.37.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.37.0",
-        "@rollup/rollup-linux-x64-gnu": "4.37.0",
-        "@rollup/rollup-linux-x64-musl": "4.37.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.37.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.37.0",
-        "@rollup/rollup-win32-x64-msvc": "4.37.0",
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -1062,9 +1199,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "vite": "^6.0.5"
   },
   "dependencies": {
-    "flatbush": "^4.6.2",
-    "kdbush": "^4.1.0",
     "polygon-clipping": "^0.15.7",
     "robust-point-in-polygon": "^1.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
   },
   "devDependencies": {
     "@types/papaparse": "^5.3.16",
+    "papaparse": "^5.5.3",
     "typescript": "~5.6.2",
-    "vite": "^6.0.5",
-    "papaparse": "^5.5.3"
+    "vite": "^6.0.5"
   },
   "dependencies": {
+    "flatbush": "^4.6.2",
+    "kdbush": "^4.1.0",
     "polygon-clipping": "^0.15.7",
     "robust-point-in-polygon": "^1.0.3"
   }


### PR DESCRIPTION
https://github.com/fizzstudio/Future-Work/issues/99

- Builds two datapoint trees, both of which are effectively used for nearest-neighbor detection, although one is used for finding all neighbors within a set distance, and the other is used for finding the closest n neighbors. Both of these packages were made by the same guy, and they're both ISC licensed, small, and very fast, so I'm willing to overlook the silliness of building what's basically the same tree twice with slightly different functional capability, although there may be technical details that I'm just not aware of as well. If it ever becomes a problem, I can try to find a single package that does both. In any case, this still vastly speeds up the steps of selecting epsilon before clustering, and building the clusters themselves. This address P1 and P2
- Remove repeated .flat() call from for loop. This address P3
- Uses a map to prevent multiple calls to findIndex() when assigning IDs to convex hull points. This address P4
- Use indexed array to avoid deep cloning masterArray when assigning density rankings. This address P7